### PR TITLE
Fix watchstate template linking to https instead of http

### DIFF
--- a/arabcoders/watchstate.xml
+++ b/arabcoders/watchstate.xml
@@ -27,7 +27,7 @@
     <Overview>Self-hosted service to sync your plex, jellyfin and emby play state. without relying on 3rd-party external
         services.
     </Overview>
-    <WebUI>https://[IP]:[PORT:8080]</WebUI>
+    <WebUI>http://[IP]:[PORT:8080]</WebUI>
     <TemplateURL>https://raw.githubusercontent.com/arabcoders/unraid-templates/master/arabcoders/watchstate.xml
     </TemplateURL>
     <Icon>https://raw.githubusercontent.com/arabcoders/watchstate/master/frontend/public/favicon.ico</Icon>


### PR DESCRIPTION
When creating the container in Unraid with default settings the WebUI uses HTTP but the template includes an HTTPS link by default. This causes an SSL error in the browser when opening the WebUI.

This change fixes the template to use HTTP by default for the WebUI link.